### PR TITLE
Remove unsupported type annotations

### DIFF
--- a/pyovpn_as/api/cli.py
+++ b/pyovpn_as/api/cli.py
@@ -8,7 +8,7 @@ Attributes:
 
 import logging
 from datetime import datetime
-from typing import Any, TypedDict, TypeVar
+from typing import TypeVar
 
 from pyovpn_as.api.exceptions import (ApiClientParameterError,
                                       ApiClientPasswordComplexityError,
@@ -141,12 +141,7 @@ class RemoteSacli:
             raise complexity_err
         
         return True
-
-    
-    class SetLocalPasswordReturnVal(TypedDict):
-        status: bool
-        reason: str
-    
+            
 
     def UserPropPut(
         self,
@@ -154,7 +149,7 @@ class RemoteSacli:
         key: str,
         value: XML_RPC_VAL,
         noui: bool=False
-    ) -> list[bool, dict]:
+    ) -> list:
         """Add a property to a user profile (create user profile if it doesn't
            exist)
 
@@ -177,9 +172,9 @@ class RemoteSacli:
 
     def UserPropGet(
         self,
-        pfilt: list[str]=None,
-        tfilt: list[str]=None
-    ) -> dict[str, dict[str, XML_RPC_VAL]]:
+        pfilt: list=None,
+        tfilt: list=None
+    ) -> dict:
         """Retrieves a list of profiles from the server, filtering on profile
            name and profile type (e.g. user_connect or user_connect_hidden)
 
@@ -198,7 +193,7 @@ class RemoteSacli:
         self,
         user: str,
         key: str
-    ) -> list[bool, dict]:
+    ) -> list:
         """Delete a property from a profile
 
         Args:
@@ -223,7 +218,7 @@ class RemoteSacli:
         """
         self._RpcClient.UserPropProfileDelete(user)
 
-    def UserPropCount(self, tfilt: list[str]=None) -> int:
+    def UserPropCount(self, tfilt: list=None) -> int:
         """Count the number of profiles that exist by filtering on profile type
 
         Args:
@@ -249,7 +244,7 @@ class RemoteSacli:
         new_pass: str,
         cur_pass: str=None,
         ignore_checks: bool=False
-    ) -> SetLocalPasswordReturnVal:
+    ) -> dict:
         """Set the password for a user if using local auth
 
         This function works a little differently to how the CLI function works
@@ -390,7 +385,7 @@ class RemoteSacli:
         """
         return self._RpcClient.GetUserlogin(user)
 
-    def Get1(self, cn: str) -> list[str]:
+    def Get1(self, cn: str) -> list:
         """Get a unified connection profile for the given common name
 
         This connection profile can be written to a file for import into most
@@ -406,7 +401,7 @@ class RemoteSacli:
         """
         return self._RpcClient.Get1(cn)
 
-    def EnumClients(self) -> list[str]:
+    def EnumClients(self) -> list:
         """Fetch the list of client names in the database where a client is a
            common name that can connect to the VPN
 
@@ -416,8 +411,8 @@ class RemoteSacli:
         return self._RpcClient.EnumClients()
 
     def ConfigQuery(
-        self, prof: str=None, plist: list[str]=None
-    ) -> dict[str, str]:
+        self, prof: str=None, plist: list=None
+    ) -> dict:
         """Fetch the configuration by filtering on the given search terms
 
         Args:
@@ -472,7 +467,7 @@ class RemoteSacli:
         return self._RpcClient.GetASLongVersion()
 
     
-    def Status(self) -> dict[str, Any]:
+    def Status(self) -> dict:
         """Get the run status of the server's internal services
 
         The returned dictionary contains the following keys:
@@ -508,7 +503,7 @@ class RemoteSacli:
         return self._RpcClient.RunStatus()
 
     
-    def GetVpnStatus(self) -> dict[str, dict[str, Any]]:
+    def GetVpnStatus(self) -> dict:
         """Returns a detailed breakdown of the status of the VPN and the client 
         connections
 
@@ -535,7 +530,7 @@ class RemoteSacli:
         return self._RpcClient.GetVPNStatus()
 
     
-    def VpnSummary(self) -> dict[str, int]:
+    def VpnSummary(self) -> dict:
         """Get a summary of the number of clients connected to the VPN
 
         Returns:

--- a/pyovpn_as/groups.py
+++ b/pyovpn_as/groups.py
@@ -133,7 +133,7 @@ class GroupOperations(ProfileOperations):
 
     
     @utils.debug_log_call()
-    def list_groups(self) -> list[GroupProfile]:
+    def list_groups(self) -> list:
         """Lists all groups present on the server
 
         Returns:

--- a/pyovpn_as/profile.py
+++ b/pyovpn_as/profile.py
@@ -208,7 +208,7 @@ class Profile:
 
     
     @property
-    def props(self) -> dict[str, Any]:
+    def props(self) -> dict:
         """dict[str, Any]: The properties set on the profile
 
         When this is requested, we immediately resolve the type in the case 

--- a/pyovpn_as/users.py
+++ b/pyovpn_as/users.py
@@ -373,7 +373,7 @@ class UserOperations(ProfileOperations):
 
     
     @utils.debug_log_call()
-    def list_users(self) -> list[UserProfile]:
+    def list_users(self) -> list:
         """Lists all users present on the server
 
         Returns:

--- a/pyovpn_as/utils.py
+++ b/pyovpn_as/utils.py
@@ -12,7 +12,7 @@ from . import exceptions
 
 logger = logging.getLogger(__name__)
 
-def debug_log_call(redact: list[Any]=['password',]):
+def debug_log_call(redact: list=['password',]):
     """Logs the function called and the arguments passed at the debug level
 
     Args:

--- a/pyovpn_as/vpn.py
+++ b/pyovpn_as/vpn.py
@@ -30,7 +30,7 @@ class ClientStatus:
         headers (dict[str, int]): A dictionary mapping header names to index in 
             the attributes list
     """
-    def __init__(self, attributes: list[str], headers: dict[str, int]):
+    def __init__(self, attributes: list, headers: dict):
         self.connected_since = datetime.fromtimestamp(attributes[
             headers['Connected Since (time_t)']
         ])
@@ -122,7 +122,7 @@ class VPNStatus:
     Raises:
         TypeError: if the connection_summary is not a dictionary
     """
-    def __init__(self, daemon_name: str, connection_summary: dict[str, Any]):
+    def __init__(self, daemon_name: str, connection_summary: dict):
         if not isinstance(connection_summary, dict):
             raise TypeError(
                 f"Expected 'dict' for arg 'connection_summary', got "
@@ -158,7 +158,7 @@ class VpnOperations:
 
     
     @property
-    def status(self) -> list[VPNStatus]:
+    def status(self) -> list:
         """list[VpnStatus]: The detailed status of connections to the VPN 
         daemons
         """

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
As described in #2 the type annotations that use subscripted types (e.g. `def x() -> list[str]`) are not supported in the current supported versions of Python.

Other unsupported type annotation definitions (e.g. TypedDict) have also been removed.

`setup.py` has been changed to reflect that Python version 3.5 is not supported anymore.